### PR TITLE
Fix meta elements

### DIFF
--- a/src/_partial/_head.jade
+++ b/src/_partial/_head.jade
@@ -1,4 +1,4 @@
-head
+head(prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# mixi: http://mixi-platform.com/ns#")
   meta(charset='utf-8')
   meta(http-equiv="X-UA-Compatible", content="IE=edge")
   meta(name="description", content="#{DESCRIPTION}")

--- a/src/_partial/_head.jade
+++ b/src/_partial/_head.jade
@@ -1,6 +1,6 @@
 head
   meta(charset='utf-8')
-  meta(http-equiv="X-UA-Compatible", content="IE=edge,chrome=1")
+  meta(http-equiv="X-UA-Compatible", content="IE=edge")
   meta(name="description", content="#{DESCRIPTION}")
   meta(name="keywords", content="#{KEYWORD}")
   meta(name="author", content="AUTHOR")


### PR DESCRIPTION
- X-UA-Compatibe の chrome=1 はオワコンっぽいです。
  - 参考: http://ichimaruni-design.com/2015/01/rendering-mode/
- OGP の各 prefix に対応したネームスペースを head 要素に追記しました。
  - mixi のネームスペースの URL が 404 になってるのが気になります……。もう使うべきではないんでしょうか。